### PR TITLE
Switch Discord Bot library from Discord.NET to DSharpPlus

### DIFF
--- a/Transcom.Web/Pages/Signup/FormViewer.razor
+++ b/Transcom.Web/Pages/Signup/FormViewer.razor
@@ -1,6 +1,6 @@
 ﻿@page "/signup/view/{SnowflakeStr}"
 @inject FormService<FormSignup> SignupService
-@inject Discord.IDiscordClient DiscordClient
+@inject DSharpPlus.DiscordClient DiscordClient
 @attribute [Authorize(Roles = UserRoles.Moderator)]
 
 <h1 class="mb-4 mb-md-5">Formulaire d'Inscription</h1>
@@ -25,8 +25,8 @@ else
 					<tr><th>Snowflake</th><td class="font-monospace">@Form.UserSnowflake</td></tr>
 					@if (User is not null)
 					{
-						<tr><th>Nom d'Utilisateur</th><td>@User.ToString()</td></tr>
-						<tr><th>Compte créé</th><td>@User.CreatedAt.UtcDateTime.ToString()</td></tr>
+						<tr><th>Nom d'Utilisateur</th><td>@User.GetFullUsername()</td></tr>
+						<tr><th>Compte créé</th><td>@User.CreationTimestamp.UtcDateTime.ToString()</td></tr>
 					}
 					@if (Form.Orientation is Orientation.Cisgender)
 					{
@@ -59,7 +59,7 @@ else
 	[Parameter] public string SnowflakeStr { get; init; }
 
 	public FormSignup Form { get; set; }
-	public Discord.IUser User { get; private set; }
+	public DSharpPlus.Entities.DiscordUser User { get; private set; }
 
 	public bool Loaded { get; private set; }
 

--- a/Transcom.Web/Program.cs
+++ b/Transcom.Web/Program.cs
@@ -1,11 +1,15 @@
 using Discord;
 using Discord.Rest;
 using Discord.WebSocket;
+using DSharpPlus;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Serilog;
+using Serilog.Events;
+using Serilog.Extensions.Logging;
 using System;
 using System.Threading.Tasks;
 using Transcom.Web.Services;
@@ -16,6 +20,19 @@ namespace Transcom.Web
 	{
 		public static async Task Main(string[] args)
 		{
+			Log.Logger = new LoggerConfiguration()
+#if DEBUG
+				.MinimumLevel.Debug()
+	.MinimumLevel.Override("Microsoft", LogEventLevel.Information)
+#else
+				.MinimumLevel.Information()
+				.MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
+#endif
+				.Enrich.FromLogContext()
+				.Enrich.WithProperty("_Source", typeof(Program).Assembly.GetName())
+				.WriteTo.Console()
+				.CreateLogger();
+
 			IHost host = CreateHostBuilder(args).Build();
 			using IServiceScope scope = host.Services.CreateScope();
 
@@ -31,18 +48,15 @@ namespace Transcom.Web
 				.ConfigureWebHostDefaults(webBuilder =>
 				{
 					webBuilder.UseStartup<Startup>();
+					webBuilder.UseSerilog();
 				});
 
 
 		public static async Task StartDiscordBotAsync(IServiceProvider services)
 		{
-			IConfiguration config = services.GetRequiredService<IConfiguration>();
-			DiscordSocketClient discordClient = services.GetRequiredService<IDiscordClient>() as DiscordSocketClient;
-			ILogger discordLogger = services.GetRequiredService<ILoggerFactory>().CreateLogger(nameof(discordClient));
+			DiscordClient client = services.GetRequiredService<DiscordClient>();
 
-			discordClient.Log += discordLogger.Log;
-			await discordClient.LoginAsync(TokenType.Bot, config["DiscordIntegration:BotToken"]);
-			await discordClient.StartAsync();
+			await client.ConnectAsync();
 		}
 	}
 }

--- a/Transcom.Web/Program.cs
+++ b/Transcom.Web/Program.cs
@@ -1,6 +1,3 @@
-using Discord;
-using Discord.Rest;
-using Discord.WebSocket;
 using DSharpPlus;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;

--- a/Transcom.Web/Services/FormEmbedHandler.cs
+++ b/Transcom.Web/Services/FormEmbedHandler.cs
@@ -1,4 +1,5 @@
-﻿using Discord;
+﻿using DSharpPlus;
+using DSharpPlus.Entities;
 using Microsoft.Extensions.Configuration;
 using System.Threading.Tasks;
 using Transcom.Web.Data.Forms;
@@ -13,9 +14,9 @@ namespace Transcom.Web.Services
 		protected const string ContentTooLargeSubstituteText = "Contenu trop large ; Utilisez le site pour consulter ce champ.";
 
 		private readonly IConfiguration config;
-		private readonly IDiscordClient discordClient;
+		private readonly DiscordClient discordClient;
 
-		public FormEmbedHandler(IConfiguration config, IDiscordClient discordClient, 
+		public FormEmbedHandler(IConfiguration config, DiscordClient discordClient, 
 			FormService<FormSignup> signup,
 			FormService<FormReport> report,
 			FormService<FormTechnical> technical)
@@ -55,11 +56,11 @@ namespace Transcom.Web.Services
 
 		public async Task SendSignupEmbedAsync(FormSignup form)
 		{
-			IGuild guild = await discordClient.GetGuildAsync(config.GetValue<ulong>("DiscordIntegration:Server:Id"));
-			ITextChannel channel = await guild.GetTextChannelAsync(config.GetValue<ulong>("DiscordIntegration:Server:Channels:Signup"));
-			IUser user = await guild.GetUserAsync(form.UserSnowflake);
+			DiscordGuild guild = await discordClient.GetGuildAsync(config.GetValue<ulong>("DiscordIntegration:Server:Id"));
+			DiscordChannel channel = guild.GetChannel(config.GetValue<ulong>("DiscordIntegration:Server:Channels:Signup"));
+			DiscordUser user = await discordClient.GetUserAsync(form.UserSnowflake);
 
-			EmbedBuilder builder = new EmbedBuilder()
+			DiscordEmbedBuilder builder = new DiscordEmbedBuilder()
 			.WithTitle($"Formulaire d'inscription : {user.Username}")
 			.WithAuthor(user)
 			.WithFooter("Transcom (Web) - Powered by Nodsoft Systems")
@@ -80,11 +81,11 @@ namespace Transcom.Web.Services
 
 		public async Task SendReportEmbedAsync(FormReport form)
 		{
-			IGuild guild = await discordClient.GetGuildAsync(config.GetValue<ulong>("DiscordIntegration:Server:Id"));
-			ITextChannel channel = await guild.GetTextChannelAsync(config.GetValue<ulong>("DiscordIntegration:Server:Channels:Report"));
-			IUser user = await guild.GetUserAsync(form.UserSnowflake);
+			DiscordGuild guild = await discordClient.GetGuildAsync(config.GetValue<ulong>("DiscordIntegration:Server:Id"));
+			DiscordChannel channel = guild.GetChannel(config.GetValue<ulong>("DiscordIntegration:Server:Channels:Report"));
+			DiscordUser user = await discordClient.GetUserAsync(form.UserSnowflake);
 
-			EmbedBuilder builder = new EmbedBuilder()
+			DiscordEmbedBuilder builder = new DiscordEmbedBuilder()
 				.WithTitle("Formulaire de Signalement")
 				.WithAuthor(user)
 				.WithFooter("Transcom (Web) - Powered by Nodsoft Systems")
@@ -104,11 +105,11 @@ namespace Transcom.Web.Services
 
 		public async Task SendTechnicalEmbedAsync(FormTechnical form)
 		{
-			IGuild guild = await discordClient.GetGuildAsync(config.GetValue<ulong>("DiscordIntegration:Server:Id"));
-			ITextChannel channel = await guild.GetTextChannelAsync(config.GetValue<ulong>("DiscordIntegration:Server:Channels:Report"));
-			IUser user = await guild.GetUserAsync(form.UserSnowflake);
+			DiscordGuild guild = await discordClient.GetGuildAsync(config.GetValue<ulong>("DiscordIntegration:Server:Id"));
+			DiscordChannel channel = guild.GetChannel(config.GetValue<ulong>("DiscordIntegration:Server:Channels:Report"));
+			DiscordUser user = await discordClient.GetUserAsync(form.UserSnowflake);
 
-			EmbedBuilder builder = new EmbedBuilder()
+			DiscordEmbedBuilder builder = new DiscordEmbedBuilder()
 				.WithTitle("Incident / Problème Technique")
 				.WithAuthor(user)
 				.WithFooter("Transcom (Web) - Powered by Nodsoft Systems")

--- a/Transcom.Web/Services/FormEmbedHandler.cs
+++ b/Transcom.Web/Services/FormEmbedHandler.cs
@@ -61,7 +61,7 @@ namespace Transcom.Web.Services
 			DiscordUser user = await discordClient.GetUserAsync(form.UserSnowflake);
 
 			DiscordEmbedBuilder builder = new DiscordEmbedBuilder()
-			.WithTitle($"Formulaire d'inscription : {user.Username}")
+			.WithTitle($"Formulaire d'inscription : {user.GetFullUsername()}")
 			.WithAuthor(user)
 			.WithFooter("Transcom (Web) - Powered by Nodsoft Systems")
 			.WithUrl($"{config["Domain"]}/signup/view/{form.UserSnowflake}")

--- a/Transcom.Web/Startup.cs
+++ b/Transcom.Web/Startup.cs
@@ -1,7 +1,5 @@
 using AspNet.Security.OAuth.Discord;
-using Discord;
-using Discord.Rest;
-using Discord.WebSocket;
+using DSharpPlus;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Builder;
@@ -12,6 +10,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using MongoDB.Driver;
+using Serilog.Extensions.Logging;
 using Transcom.Web.Services;
 using Transcom.Web.Services.Authentication;
 
@@ -65,7 +64,14 @@ namespace Transcom.Web
 			services.AddSingleton(typeof(FormService<>));
 			services.AddSingleton<FormEmbedHandler>();
 			services.AddSingleton<IMongoClient, MongoClient>(c => new(Configuration["MongoDb:ConnectionString"]));
-			services.AddSingleton<IDiscordClient, DiscordSocketClient>();
+
+			services.AddSingleton(new DiscordClient(new DiscordConfiguration()
+			{
+				TokenType = TokenType.Bot,
+				Intents = DiscordIntents.All,
+				Token = Configuration["DiscordIntegration:BotToken"],
+				LoggerFactory = new SerilogLoggerFactory()
+			}));
 
 			services.AddScoped<IClaimsTransformation, WebAppClaims>();
 		}

--- a/Transcom.Web/Transcom.Web.csproj
+++ b/Transcom.Web/Transcom.Web.csproj
@@ -23,15 +23,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspNet.Security.OAuth.Discord" Version="5.0.3" />
-    <PackageReference Include="Discord.Net.Webhook" Version="2.3.1" />
-    <PackageReference Include="Discord.Net.WebSocket" Version="2.3.1" />
-    <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="4.2.3">
+    <PackageReference Include="AspNet.Security.OAuth.Discord" Version="5.0.4" />
+    <PackageReference Include="DSharpPlus" Version="4.0.0" />
+    <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="4.3.0-beta">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="2.1.113" />
-    <PackageReference Include="MongoDB.Driver" Version="2.12.1" />
+    <PackageReference Include="MongoDB.Driver" Version="2.13.0-beta1" />
+    <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">

--- a/Transcom.Web/Utilities.cs
+++ b/Transcom.Web/Utilities.cs
@@ -1,4 +1,5 @@
-﻿using Discord;
+﻿using DSharpPlus;
+using DSharpPlus.Entities;
 using Microsoft.Extensions.Logging;
 using System.Threading.Tasks;
 using Transcom.Web.Data;
@@ -8,28 +9,6 @@ namespace Transcom.Web
 {
 	public static class Utilities
 	{
-		public static Task Log(this ILogger logger, LogMessage logMessage) // Adapting MS's ILogger.Log() for Discord.NET events
-		{
-			logger.Log
-			(
-				logMessage.Severity switch
-				{
-					LogSeverity.Critical => LogLevel.Critical,
-					LogSeverity.Debug => LogLevel.Debug,
-					LogSeverity.Error => LogLevel.Error,
-					LogSeverity.Info => LogLevel.Information,
-					LogSeverity.Verbose => LogLevel.Trace,
-					LogSeverity.Warning => LogLevel.Warning,
-					_ => LogLevel.None
-				},
-				logMessage.Exception,
-				logMessage.Message,
-				logMessage.Source
-			);
-
-			return Task.CompletedTask;
-		}
-
 		public static string ToDisplayString(this Orientation orientation) => orientation switch
 		{
 			Orientation.Transgender => "Transgenre",
@@ -60,5 +39,10 @@ namespace Transcom.Web
 			TechnicalType.Other => "Autre",
 			_ => ""
 		};
+
+		public static DiscordEmbedBuilder WithAuthor(this DiscordEmbedBuilder embed, DiscordUser user)
+		{
+			return embed.WithAuthor(user.Username, null, user.GetAvatarUrl(ImageFormat.Auto, 128));
+		}
 	}
 }

--- a/Transcom.Web/Utilities.cs
+++ b/Transcom.Web/Utilities.cs
@@ -42,7 +42,9 @@ namespace Transcom.Web
 
 		public static DiscordEmbedBuilder WithAuthor(this DiscordEmbedBuilder embed, DiscordUser user)
 		{
-			return embed.WithAuthor(user.Username, null, user.GetAvatarUrl(ImageFormat.Auto, 128));
+			return embed.WithAuthor(user.GetFullUsername(), null, user.GetAvatarUrl(ImageFormat.Auto, 128));
 		}
+
+		public static string GetFullUsername(this DiscordUser user) => $"{user.Username}#{user.Discriminator}";
 	}
 }


### PR DESCRIPTION
As the DSharpPlus library has way more support and is better maintained than Discord.NET, with updates and enhancements being much more frequent, we must consider it as our first choice going forwards as our Discord Bot library.